### PR TITLE
Fix mistype

### DIFF
--- a/src/main/java/com/james090500/APIManager/Utils/WebRequest.java
+++ b/src/main/java/com/james090500/APIManager/Utils/WebRequest.java
@@ -63,7 +63,7 @@ public class WebRequest {
 	}
 	
 	public static boolean isRequestLimit(JsonElement json) {		
-		return json.getAsJsonObject().get("error") == null;
+		return json.getAsJsonObject().get("error") != null;
 	}
 	
 }


### PR DESCRIPTION
Mistype is causing that any request that is not limited shows as if it is limited.